### PR TITLE
Implement metadata generator service

### DIFF
--- a/knotsrepus_archiver/knotsrepus_archiver_stack.py
+++ b/knotsrepus_archiver/knotsrepus_archiver_stack.py
@@ -137,66 +137,96 @@ class KnotsrepusArchiverStack(core.Stack):
             partition_key=dynamodb.Attribute(name="created_utc", type=dynamodb.AttributeType.NUMBER),
             projection_type=dynamodb.ProjectionType.ALL
         )
-        # metadata_table.add_global_secondary_index(
-        #     index_name="ArchiveMetadataByScore",
-        #     partition_key=dynamodb.Attribute(name="score", type=dynamodb.AttributeType.NUMBER),
-        #     projection_type=dynamodb.ProjectionType.ALL
-        # )
-        # metadata_table.add_global_secondary_index(
-        #     index_name="ArchiveMetadataByAuthorChronological",
-        #     partition_key=dynamodb.Attribute(name="author", type=dynamodb.AttributeType.STRING),
-        #     sort_key=dynamodb.Attribute(name="created_utc", type=dynamodb.AttributeType.NUMBER),
-        #     projection_type=dynamodb.ProjectionType.ALL
-        # )
-        # metadata_table.add_global_secondary_index(
-        #     index_name="ArchiveMetadataByAuthorScore",
-        #     partition_key=dynamodb.Attribute(name="author", type=dynamodb.AttributeType.STRING),
-        #     sort_key=dynamodb.Attribute(name="score", type=dynamodb.AttributeType.NUMBER),
-        #     projection_type=dynamodb.ProjectionType.ALL
-        # )
-        # metadata_table.add_global_secondary_index(
-        #     index_name="ArchiveMetadataByPostTypeChronological",
-        #     partition_key=dynamodb.Attribute(name="post_type", type=dynamodb.AttributeType.STRING),
-        #     sort_key=dynamodb.Attribute(name="created_utc", type=dynamodb.AttributeType.NUMBER),
-        #     projection_type=dynamodb.ProjectionType.ALL
-        # )
-        # metadata_table.add_global_secondary_index(
-        #     index_name="ArchiveMetadataByPostTypeScore",
-        #     partition_key=dynamodb.Attribute(name="post_type", type=dynamodb.AttributeType.STRING),
-        #     sort_key=dynamodb.Attribute(name="score", type=dynamodb.AttributeType.NUMBER),
-        #     projection_type=dynamodb.ProjectionType.ALL
-        # )
+        metadata_table.add_global_secondary_index(
+            index_name="ArchiveMetadataByScore",
+            partition_key=dynamodb.Attribute(name="score", type=dynamodb.AttributeType.NUMBER),
+            projection_type=dynamodb.ProjectionType.ALL
+        )
+        metadata_table.add_global_secondary_index(
+            index_name="ArchiveMetadataByAuthorChronological",
+            partition_key=dynamodb.Attribute(name="author", type=dynamodb.AttributeType.STRING),
+            sort_key=dynamodb.Attribute(name="created_utc", type=dynamodb.AttributeType.NUMBER),
+            projection_type=dynamodb.ProjectionType.ALL
+        )
+        metadata_table.add_global_secondary_index(
+            index_name="ArchiveMetadataByAuthorScore",
+            partition_key=dynamodb.Attribute(name="author", type=dynamodb.AttributeType.STRING),
+            sort_key=dynamodb.Attribute(name="score", type=dynamodb.AttributeType.NUMBER),
+            projection_type=dynamodb.ProjectionType.ALL
+        )
+        metadata_table.add_global_secondary_index(
+            index_name="ArchiveMetadataByPostTypeChronological",
+            partition_key=dynamodb.Attribute(name="post_type", type=dynamodb.AttributeType.STRING),
+            sort_key=dynamodb.Attribute(name="created_utc", type=dynamodb.AttributeType.NUMBER),
+            projection_type=dynamodb.ProjectionType.ALL
+        )
+        metadata_table.add_global_secondary_index(
+            index_name="ArchiveMetadataByPostTypeScore",
+            partition_key=dynamodb.Attribute(name="post_type", type=dynamodb.AttributeType.STRING),
+            sort_key=dynamodb.Attribute(name="score", type=dynamodb.AttributeType.NUMBER),
+            projection_type=dynamodb.ProjectionType.ALL
+        )
 
         metadata_table.auto_scale_global_secondary_index_read_capacity(
             index_name="ArchiveMetadataByCreatedUtc",
             min_capacity=5,
             max_capacity=1000,
         ).scale_on_utilization(target_utilization_percent=70)
-        # metadata_table.auto_scale_global_secondary_index_read_capacity(
-        #     index_name="ArchiveMetadataByScore",
-        #     min_capacity=5,
-        #     max_capacity=1000,
-        # ).scale_on_utilization(target_utilization_percent=70)
-        # metadata_table.auto_scale_global_secondary_index_read_capacity(
-        #     index_name="ArchiveMetadataByAuthorChronological",
-        #     min_capacity=5,
-        #     max_capacity=1000,
-        # ).scale_on_utilization(target_utilization_percent=70)
-        # metadata_table.auto_scale_global_secondary_index_read_capacity(
-        #     index_name="ArchiveMetadataByAuthorScore",
-        #     min_capacity=5,
-        #     max_capacity=1000,
-        # ).scale_on_utilization(target_utilization_percent=70)
-        # metadata_table.auto_scale_global_secondary_index_read_capacity(
-        #     index_name="ArchiveMetadataByPostTypeChronological",
-        #     min_capacity=5,
-        #     max_capacity=1000,
-        # ).scale_on_utilization(target_utilization_percent=70)
-        # metadata_table.auto_scale_global_secondary_index_read_capacity(
-        #     index_name="ArchiveMetadataByPostTypeScore",
-        #     min_capacity=5,
-        #     max_capacity=1000,
-        # ).scale_on_utilization(target_utilization_percent=70)
+        metadata_table.auto_scale_global_secondary_index_write_capacity(
+            index_name="ArchiveMetadataByCreatedUtc",
+            min_capacity=5,
+            max_capacity=1000,
+        ).scale_on_utilization(target_utilization_percent=70)
+        metadata_table.auto_scale_global_secondary_index_read_capacity(
+            index_name="ArchiveMetadataByScore",
+            min_capacity=5,
+            max_capacity=1000,
+        ).scale_on_utilization(target_utilization_percent=70)
+        metadata_table.auto_scale_global_secondary_index_write_capacity(
+            index_name="ArchiveMetadataByScore",
+            min_capacity=5,
+            max_capacity=1000,
+        ).scale_on_utilization(target_utilization_percent=70)
+        metadata_table.auto_scale_global_secondary_index_read_capacity(
+            index_name="ArchiveMetadataByAuthorChronological",
+            min_capacity=5,
+            max_capacity=1000,
+        ).scale_on_utilization(target_utilization_percent=70)
+        metadata_table.auto_scale_global_secondary_index_write_capacity(
+            index_name="ArchiveMetadataByAuthorChronological",
+            min_capacity=5,
+            max_capacity=1000,
+        ).scale_on_utilization(target_utilization_percent=70)
+        metadata_table.auto_scale_global_secondary_index_read_capacity(
+            index_name="ArchiveMetadataByAuthorScore",
+            min_capacity=5,
+            max_capacity=1000,
+        ).scale_on_utilization(target_utilization_percent=70)
+        metadata_table.auto_scale_global_secondary_index_write_capacity(
+            index_name="ArchiveMetadataByAuthorScore",
+            min_capacity=5,
+            max_capacity=1000,
+        ).scale_on_utilization(target_utilization_percent=70)
+        metadata_table.auto_scale_global_secondary_index_read_capacity(
+            index_name="ArchiveMetadataByPostTypeChronological",
+            min_capacity=5,
+            max_capacity=1000,
+        ).scale_on_utilization(target_utilization_percent=70)
+        metadata_table.auto_scale_global_secondary_index_write_capacity(
+            index_name="ArchiveMetadataByPostTypeChronological",
+            min_capacity=5,
+            max_capacity=1000,
+        ).scale_on_utilization(target_utilization_percent=70)
+        metadata_table.auto_scale_global_secondary_index_read_capacity(
+            index_name="ArchiveMetadataByPostTypeScore",
+            min_capacity=5,
+            max_capacity=1000,
+        ).scale_on_utilization(target_utilization_percent=70)
+        metadata_table.auto_scale_global_secondary_index_write_capacity(
+            index_name="ArchiveMetadataByPostTypeScore",
+            min_capacity=5,
+            max_capacity=1000,
+        ).scale_on_utilization(target_utilization_percent=70)
 
         return metadata_table
 

--- a/knotsrepus_archiver/knotsrepus_archiver_stack.py
+++ b/knotsrepus_archiver/knotsrepus_archiver_stack.py
@@ -120,6 +120,41 @@ class KnotsrepusArchiverStack(core.Stack):
             ]
         )
 
+        default_security_group = ec2.SecurityGroup.from_security_group_id(
+            self,
+            "SecurityGroup",
+            vpc.vpc_default_security_group
+        )
+
+        vpc.add_interface_endpoint(
+            "SecretsManagerEndpoint",
+            service=ec2.InterfaceVpcEndpointAwsService.SECRETS_MANAGER,
+            security_groups=[default_security_group]
+        )
+        vpc.add_interface_endpoint(
+            "EcrDockerEndpoint",
+            service=ec2.InterfaceVpcEndpointAwsService.ECR_DOCKER,
+            security_groups=[default_security_group]
+        )
+        vpc.add_interface_endpoint(
+            "EcrApiEndpoint",
+            service=ec2.InterfaceVpcEndpointAwsService.ECR,
+            security_groups=[default_security_group]
+        )
+        vpc.add_interface_endpoint(
+            "CloudWatchEndpoint",
+            service=ec2.InterfaceVpcEndpointAwsService.CLOUDWATCH_LOGS,
+            security_groups=[default_security_group]
+        )
+        vpc.add_gateway_endpoint(
+            "S3Endpoint",
+            service=ec2.GatewayVpcEndpointAwsService.S3
+        )
+        vpc.add_gateway_endpoint(
+            "DynamoDbEndpoint",
+            service=ec2.GatewayVpcEndpointAwsService.DYNAMODB
+        )
+
         cluster = ecs.Cluster(
             self,
             "Cluster",

--- a/src/common/archiver_config.py
+++ b/src/common/archiver_config.py
@@ -40,9 +40,9 @@ class DynamoDBConfigSource(ArchiverConfigSource):
         async with self.session.resource("dynamodb") as dynamodb:
             table = await dynamodb.Table(self.table_name)
 
-            response = await table.query(KeyConditionExpression=Key("key").eq(key))
+            response = await table.query(KeyConditionExpression=Key("key").eq(key), ScanIndexForward=False, Limit=1)
             items = response["Items"]
-            return max(items, key=lambda item: item["version"])["value"] if len(items) > 0 else None
+            return items[0]["value"] if len(items) > 0 else None
 
     async def put_config(self, **kwargs):
         async with self.session.resource("dynamodb") as dynamodb:

--- a/src/common/archiver_config.py
+++ b/src/common/archiver_config.py
@@ -3,22 +3,17 @@ from datetime import datetime
 
 import aioboto3
 from boto3.dynamodb.conditions import Key
-from pydantic import BaseModel
 
 from src.common import log_utils
 
 
-class ArchiverConfig(BaseModel):
-    after_utc: int
-
-
 class ArchiverConfigSource(ABC):
     @abstractmethod
-    async def get_config(self):
+    async def get_config(self, key: str):
         pass
 
     @abstractmethod
-    async def put_config(self, config: ArchiverConfig):
+    async def put_config(self, **kwargs):
         pass
 
 
@@ -26,11 +21,14 @@ class StubConfigSource(ArchiverConfigSource):
     def __init__(self):
         self.logger = log_utils.get_logger(__name__)
 
-    async def get_config(self):
-        return ArchiverConfig(after_utc=1623196800)
+    async def get_config(self, key: str):
+        if key == "after_utc":
+            return 1623196800
+        else:
+            return "testid"
 
-    async def put_config(self, config: ArchiverConfig):
-        self.logger.info(f"Stubbed: put_config {config}")
+    async def put_config(self, **kwargs):
+        self.logger.info(f"Stubbed: put_config {kwargs}")
 
 
 class DynamoDBConfigSource(ArchiverConfigSource):
@@ -38,26 +36,26 @@ class DynamoDBConfigSource(ArchiverConfigSource):
         self.session = session
         self.table_name = table_name
 
-    async def get_config(self):
+    async def get_config(self, key):
         async with self.session.resource("dynamodb") as dynamodb:
             table = await dynamodb.Table(self.table_name)
 
-            response = await table.query(KeyConditionExpression=Key("key").eq("after_utc"))
+            response = await table.query(KeyConditionExpression=Key("key").eq(key))
             items = response["Items"]
-            after_utc = int(max(items, key=lambda item: item["version"])["value"]) if len(items) > 0 else 0
+            return max(items, key=lambda item: item["version"])["value"] if len(items) > 0 else None
 
-            return ArchiverConfig(after_utc=after_utc)
-
-    async def put_config(self, config: ArchiverConfig):
+    async def put_config(self, **kwargs):
         async with self.session.resource("dynamodb") as dynamodb:
             table = await dynamodb.Table(self.table_name)
 
             version = int(datetime.utcnow().timestamp())
 
-            await table.put_item(
-                Item={
-                    "key": "after_utc",
-                    "version": version,
-                    "value": config.after_utc,
-                }
-            )
+            async with table.batch_writer() as batch:
+                for key, value in kwargs.items():
+                    await batch.put_item(
+                        Item={
+                            "key": key,
+                            "version": version,
+                            "value": value,
+                        }
+                    )

--- a/src/common/filesystem.py
+++ b/src/common/filesystem.py
@@ -79,7 +79,7 @@ class S3FileSystem(FileSystem):
             paginator = s3.get_paginator("list_objects_v2")
             async for result in paginator.paginate(Bucket=self.bucket_name, Delimiter="/", **kwargs):
                 for prefix in result["CommonPrefixes"]:
-                    yield prefix
+                    yield prefix["Prefix"]
 
     async def read(self, path):
         async with self.session.client("s3") as s3:

--- a/src/common/filesystem.py
+++ b/src/common/filesystem.py
@@ -1,3 +1,4 @@
+import json
 from abc import ABC, abstractmethod
 
 import aioboto3
@@ -18,6 +19,16 @@ class FileSystem(ABC):
     async def write_raw(self, path, data):
         pass
 
+    # noinspection PyUnreachableCode
+    @abstractmethod
+    async def list_dirs(self, **kwargs):
+        if False:
+            yield
+
+    @abstractmethod
+    async def read(self, path):
+        pass
+
 
 class StubFileSystem(FileSystem):
     def __init__(self):
@@ -31,6 +42,19 @@ class StubFileSystem(FileSystem):
 
     async def write_raw(self, path, data):
         self.logger.info(f"Stubbed: write_raw {len(data)} bytes to {path}")
+
+    async def list_dirs(self, **kwargs):
+        for dir in ["testid", "testic", "testib", "testia", "testi9"]:
+            yield f"{dir}/"
+
+    async def read(self, path):
+        return json.dumps({
+            "link_flair_text": "DD",
+            "created_utc": 1630450800,
+            "author": "VoxUmbra",
+            "title": path,
+            "score": 1,
+        })
 
 
 class S3FileSystem(FileSystem):
@@ -49,3 +73,17 @@ class S3FileSystem(FileSystem):
 
     async def write_raw(self, path, data):
         await self.write(path, data)
+
+    async def list_dirs(self, **kwargs):
+        async with self.session.client("s3") as s3:
+            paginator = s3.get_paginator("list_objects_v2")
+            async for result in paginator.paginate(Bucket=self.bucket_name, Delimiter="/", **kwargs):
+                for prefix in result["CommonPrefixes"]:
+                    yield prefix
+
+    async def read(self, path):
+        async with self.session.client("s3") as s3:
+            response = await s3.get_object(Bucket=self.bucket_name, Key=path)
+            body = await response["Body"]
+
+            return await body.read()

--- a/src/common/filesystem.py
+++ b/src/common/filesystem.py
@@ -84,6 +84,6 @@ class S3FileSystem(FileSystem):
     async def read(self, path):
         async with self.session.client("s3") as s3:
             response = await s3.get_object(Bucket=self.bucket_name, Key=path)
-            body = await response["Body"]
+            body = response["Body"]
 
             return await body.read()

--- a/src/common/metadata.py
+++ b/src/common/metadata.py
@@ -1,0 +1,90 @@
+from abc import ABC, abstractmethod
+
+import aioboto3
+
+from src.common import log_utils
+
+
+class MetadataService(ABC):
+    @abstractmethod
+    async def list(self):
+        pass
+
+    @abstractmethod
+    async def get(self, submission_id: str):
+        pass
+
+    @abstractmethod
+    async def put(self, submission_id: str, metadata):
+        pass
+
+
+class DynamoDBMetadataService(MetadataService):
+    def __init__(self, session: aioboto3.Session, table_name: str):
+        self.session = session
+        self.table_name = table_name
+
+    async def list(self):
+        async with self.session.resource("dynamodb") as dynamodb:
+            table = await dynamodb.Table(self.table_name)
+
+            return await self.__paginate(table.scan)
+
+    async def get(self, submission_id: str):
+        async with self.session.resource("dynamodb") as dynamodb:
+            table = await dynamodb.Table(self.table_name)
+
+            response = await table.get_item(Key={"submission_id": submission_id})
+
+            return response.get("Item")
+
+    async def put(self, submission_id: str, metadata: dict):
+        async with self.session.resource("dynamodb") as dynamodb:
+            table = await dynamodb.Table(self.table_name)
+
+            await table.put_item(
+                Item={
+                    "submission_id": submission_id,
+                    **metadata
+                }
+            )
+
+    async def __paginate(self, query_func, **kwargs):
+        result = []
+        last_evaluated_key = None
+
+        while True:
+            if last_evaluated_key is not None:
+                kwargs = {**kwargs, "ExclusiveStartKey": last_evaluated_key}
+
+            response = await query_func(**kwargs)
+
+            result.extend(response["Items"])
+
+            last_evaluated_key = response.get("LastEvaluatedKey")
+            if last_evaluated_key is None:
+                break
+
+        return result
+
+
+class StubMetadataService(MetadataService):
+    def __init__(self):
+        self.logger = log_utils.get_logger(__name__)
+
+    async def list(self):
+        return [self.get(submission_id) for submission_id in ["testid", "testic", "testib", "testia", "testi9"]]
+
+    async def get(self, submission_id: str):
+        return {
+            "submission_id": submission_id,
+            "created_utc": 1630450800,
+            "author": "VoxUmbra",
+            "title": submission_id,
+            "score": 1,
+            "post_type": "DD",
+        }
+
+    async def put(self, submission_id: str, metadata):
+        self.logger.info(f"Stubbed: put {submission_id} {metadata}")
+

--- a/src/metadata-generator/Dockerfile
+++ b/src/metadata-generator/Dockerfile
@@ -1,0 +1,13 @@
+FROM public.ecr.aws/amazonlinux/amazonlinux:latest
+
+RUN amazon-linux-extras enable python3.8 && \
+    yum install -y python3.8 python38-devel gcc
+
+COPY metadata-generator/main.py /app/main.py
+COPY common /app/src/common
+COPY requirements.txt /app/requirements.txt
+
+WORKDIR /app
+RUN python3.8 -m pip install -r requirements.txt
+
+CMD ["python3.8", "main.py"]

--- a/src/metadata-generator/main.py
+++ b/src/metadata-generator/main.py
@@ -1,0 +1,98 @@
+import asyncio
+import json
+import os
+
+import aioboto3
+
+from src.common import log_utils
+from src.common.archiver_config import DynamoDBConfigSource, StubConfigSource, ArchiverConfigSource
+from src.common.filesystem import S3FileSystem, StubFileSystem, FileSystem
+from src.common.metadata import DynamoDBMetadataService, StubMetadataService, MetadataService
+
+
+def derive_post_type(flair_text: str):
+    flair_keywords = {
+        "dd": "dd",
+        "discussion": "discussion",
+        "opinion": "discussion",
+        "shitpost": "shitpost",
+        "meme": "shitpost",
+        "social media": "social_media",
+        "data": "data",
+        "hodl": "fluff",
+        "fluff": "fluff",
+        "news": "news",
+        "daily": "daily",
+    }
+
+    if flair_text is None:
+        return "unknown"
+
+    flair_text = flair_text.lower()
+
+    for keyword, post_type in flair_keywords.items():
+        if keyword in flair_text:
+            return post_type
+
+    return "unknown"
+
+
+async def main(config_source: ArchiverConfigSource, filesystem: FileSystem, metadata_service: MetadataService):
+    logger = log_utils.get_logger("metadata-generator")
+    logger.info("Building KNOTSREPUS archive metadata...")
+
+    last_generated_metadata = await config_source.get_config("last_generated_metadata") or ""
+    metadata_count = 0
+
+    async for dir in filesystem.list_dirs(StartAfter=last_generated_metadata):
+        submission_id = dir.replace("/", "")
+
+        logger.info(f"Creating metadata for '{submission_id}'...")
+
+        data = json.loads(await filesystem.read(f"{submission_id}/post.json"))
+
+        link_flair_text = data.get("link_flair_text")
+        post_type = derive_post_type(link_flair_text)
+
+        metadata = {
+            "submission_id": submission_id,
+            "created_utc": data["created_utc"],
+            "author": data["author"],
+            "title": data["title"],
+            "score": data["score"],
+            "post_type": post_type,
+        }
+
+        await metadata_service.put(submission_id, metadata)
+
+        last_generated_metadata = submission_id
+
+        await config_source.put_config(last_generated_metadata=last_generated_metadata)
+
+        metadata_count += 1
+
+    logger.info(f"Metadata generated for {metadata_count} submissions.")
+
+
+if __name__ == "__main__":
+    session = aioboto3.Session()
+
+    config_table_name = os.environ.get("CONFIG_TABLE_NAME")
+    if config_table_name is not None:
+        config_source = DynamoDBConfigSource(session, config_table_name)
+    else:
+        config_source = StubConfigSource()
+
+    metadata_table_name = os.environ.get("METADATA_TABLE_NAME")
+    if metadata_table_name is not None:
+        metadata_service = DynamoDBMetadataService(session, metadata_table_name)
+    else:
+        metadata_service = StubMetadataService()
+
+    archive_data_bucket = os.environ.get("ARCHIVE_DATA_BUCKET")
+    if archive_data_bucket is not None:
+        filesystem = S3FileSystem(archive_data_bucket)
+    else:
+        filesystem = StubFileSystem()
+
+    asyncio.get_event_loop().run_until_complete(main(config_source, filesystem, metadata_service))

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -4,4 +4,3 @@ aioboto3==9.0.0
 python-dateutil==2.8.1
 boto3==1.17.49
 botocore==1.20.49
-pydantic==1.8.2

--- a/src/submission-finder/main.py
+++ b/src/submission-finder/main.py
@@ -5,7 +5,7 @@ from datetime import datetime
 import aioboto3
 
 from src.common import log_utils, pushshift
-from src.common.archiver_config import DynamoDBConfigSource, StubConfigSource, ArchiverConfigSource, ArchiverConfig
+from src.common.archiver_config import DynamoDBConfigSource, StubConfigSource, ArchiverConfigSource
 from src.common.messaging import SNSMessagingService, StubMessagingService, MessagingService
 
 
@@ -13,8 +13,7 @@ async def main(config_source: ArchiverConfigSource, messaging_service: Messaging
     logger = log_utils.get_logger("submission-finder")
     logger.info("Retrieving /r/superstonk submissions...")
 
-    config = await config_source.get_config()
-    after_utc = config.after_utc
+    after_utc = int(await config_source.get_config("after_utc") or 0)
     submission_count = 0
 
     while True:
@@ -39,7 +38,7 @@ async def main(config_source: ArchiverConfigSource, messaging_service: Messaging
         for submission in chunk:
             await messaging_service.send_message(submission["id"])
 
-        await config_source.put_config(ArchiverConfig(after_utc=after_utc))
+        await config_source.put_config(after_utc=after_utc)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Adds a Fargate service to crawl through the S3 bucket and generate metadata for submissions.
This metadata is placed into a DynamoDB table, which can be used by the API to provide some filtering functionality.

Current list of stored metadata:
* The submission type
* The creation timestamp
* The author
* The submission title
* The number of updoots

Additional changes:
* Refactored `ArchiverConfigSource` and subclasses to get/put by key
* Added `read()` and `list_dirs()` methods to `FileSystem` and subclasses to facilitate crawling the S3 bucket