### PR TITLE
Incorporate KNOTSREPUS API into this repository

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import os
 
 from aws_cdk import core
 
@@ -6,6 +7,13 @@ from knotsrepus_archiver.knotsrepus_archiver_stack import KnotsrepusArchiverStac
 
 
 app = core.App()
-KnotsrepusArchiverStack(app, "KnotsrepusArchiver")
+KnotsrepusArchiverStack(
+    app,
+    "KnotsrepusArchiver",
+    env=core.Environment(
+        account=os.environ["CDK_DEFAULT_ACCOUNT"],
+        region=os.environ["CDK_DEFAULT_REGION"]
+    )
+)
 
 app.synth()

--- a/knotsrepus_archiver/knotsrepus_archiver_stack.py
+++ b/knotsrepus_archiver/knotsrepus_archiver_stack.py
@@ -258,6 +258,8 @@ class KnotsrepusArchiverStack(core.Stack):
             "KnotsrepusApiGateway",
             handler=knotsrepus_api_backend_lambda,
             domain_name=apigateway.DomainName(
+                self,
+                "DomainName",
                 domain_name="api.knotsrepus.net",
                 certificate=certificatemanager.Certificate(
                     self,

--- a/knotsrepus_archiver/knotsrepus_archiver_stack.py
+++ b/knotsrepus_archiver/knotsrepus_archiver_stack.py
@@ -145,12 +145,12 @@ class KnotsrepusArchiverStack(core.Stack):
             sort_key=dynamodb.Attribute(name="created_utc", type=dynamodb.AttributeType.NUMBER),
             projection_type=dynamodb.ProjectionType.ALL
         )
-        # metadata_table.add_global_secondary_index(
-        #     index_name="ArchiveMetadataByDummyScore",
-        #     partition_key=dynamodb.Attribute(name="dummy", type=dynamodb.AttributeType.STRING),
-        #     sort_key=dynamodb.Attribute(name="score", type=dynamodb.AttributeType.NUMBER),
-        #     projection_type=dynamodb.ProjectionType.ALL
-        # )
+        metadata_table.add_global_secondary_index(
+            index_name="ArchiveMetadataByDummyScore",
+            partition_key=dynamodb.Attribute(name="dummy", type=dynamodb.AttributeType.STRING),
+            sort_key=dynamodb.Attribute(name="score", type=dynamodb.AttributeType.NUMBER),
+            projection_type=dynamodb.ProjectionType.ALL
+        )
         metadata_table.add_global_secondary_index(
             index_name="ArchiveMetadataByAuthorChronological",
             partition_key=dynamodb.Attribute(name="author", type=dynamodb.AttributeType.STRING),
@@ -186,16 +186,16 @@ class KnotsrepusArchiverStack(core.Stack):
             min_capacity=5,
             max_capacity=1000,
         ).scale_on_utilization(target_utilization_percent=70)
-        # metadata_table.auto_scale_global_secondary_index_read_capacity(
-        #     index_name="ArchiveMetadataByDummyScore",
-        #     min_capacity=5,
-        #     max_capacity=1000,
-        # ).scale_on_utilization(target_utilization_percent=70)
-        # metadata_table.auto_scale_global_secondary_index_write_capacity(
-        #     index_name="ArchiveMetadataByDummyScore",
-        #     min_capacity=5,
-        #     max_capacity=1000,
-        # ).scale_on_utilization(target_utilization_percent=70)
+        metadata_table.auto_scale_global_secondary_index_read_capacity(
+            index_name="ArchiveMetadataByDummyScore",
+            min_capacity=5,
+            max_capacity=1000,
+        ).scale_on_utilization(target_utilization_percent=70)
+        metadata_table.auto_scale_global_secondary_index_write_capacity(
+            index_name="ArchiveMetadataByDummyScore",
+            min_capacity=5,
+            max_capacity=1000,
+        ).scale_on_utilization(target_utilization_percent=70)
         metadata_table.auto_scale_global_secondary_index_read_capacity(
             index_name="ArchiveMetadataByAuthorChronological",
             min_capacity=5,

--- a/knotsrepus_archiver/knotsrepus_archiver_stack.py
+++ b/knotsrepus_archiver/knotsrepus_archiver_stack.py
@@ -139,12 +139,12 @@ class KnotsrepusArchiverStack(core.Stack):
             max_capacity=1000
         ).scale_on_utilization(target_utilization_percent=70)
 
-        # metadata_table.add_global_secondary_index(
-        #     index_name="ArchiveMetadataByDummyChronological",
-        #     partition_key=dynamodb.Attribute(name="dummy", type=dynamodb.AttributeType.STRING),
-        #     sort_key=dynamodb.Attribute(name="created_utc", type=dynamodb.AttributeType.NUMBER),
-        #     projection_type=dynamodb.ProjectionType.ALL
-        # )
+        metadata_table.add_global_secondary_index(
+            index_name="ArchiveMetadataByDummyChronological",
+            partition_key=dynamodb.Attribute(name="dummy", type=dynamodb.AttributeType.STRING),
+            sort_key=dynamodb.Attribute(name="created_utc", type=dynamodb.AttributeType.NUMBER),
+            projection_type=dynamodb.ProjectionType.ALL
+        )
         # metadata_table.add_global_secondary_index(
         #     index_name="ArchiveMetadataByDummyScore",
         #     partition_key=dynamodb.Attribute(name="dummy", type=dynamodb.AttributeType.STRING),
@@ -176,16 +176,16 @@ class KnotsrepusArchiverStack(core.Stack):
             projection_type=dynamodb.ProjectionType.ALL
         )
 
-        # metadata_table.auto_scale_global_secondary_index_read_capacity(
-        #     index_name="ArchiveMetadataByDummyChronological",
-        #     min_capacity=5,
-        #     max_capacity=1000,
-        # ).scale_on_utilization(target_utilization_percent=70)
-        # metadata_table.auto_scale_global_secondary_index_write_capacity(
-        #     index_name="ArchiveMetadataByDummyChronological",
-        #     min_capacity=5,
-        #     max_capacity=1000,
-        # ).scale_on_utilization(target_utilization_percent=70)
+        metadata_table.auto_scale_global_secondary_index_read_capacity(
+            index_name="ArchiveMetadataByDummyChronological",
+            min_capacity=5,
+            max_capacity=1000,
+        ).scale_on_utilization(target_utilization_percent=70)
+        metadata_table.auto_scale_global_secondary_index_write_capacity(
+            index_name="ArchiveMetadataByDummyChronological",
+            min_capacity=5,
+            max_capacity=1000,
+        ).scale_on_utilization(target_utilization_percent=70)
         # metadata_table.auto_scale_global_secondary_index_read_capacity(
         #     index_name="ArchiveMetadataByDummyScore",
         #     min_capacity=5,

--- a/knotsrepus_archiver/knotsrepus_archiver_stack.py
+++ b/knotsrepus_archiver/knotsrepus_archiver_stack.py
@@ -139,11 +139,12 @@ class KnotsrepusArchiverStack(core.Stack):
             max_capacity=1000
         ).scale_on_utilization(target_utilization_percent=70)
 
-        metadata_table.add_global_secondary_index(
-            index_name="ArchiveMetadataByCreatedUtc",
-            partition_key=dynamodb.Attribute(name="created_utc", type=dynamodb.AttributeType.NUMBER),
-            projection_type=dynamodb.ProjectionType.ALL
-        )
+        # metadata_table.add_global_secondary_index(
+        #     index_name="ArchiveMetadataByDummyChronological",
+        #     partition_key=dynamodb.Attribute(name="dummy", type=dynamodb.AttributeType.STRING),
+        #     sort_key=dynamodb.Attribute(name="created_utc", type=dynamodb.AttributeType.NUMBER),
+        #     projection_type=dynamodb.ProjectionType.ALL
+        # )
         metadata_table.add_global_secondary_index(
             index_name="ArchiveMetadataByScore",
             partition_key=dynamodb.Attribute(name="score", type=dynamodb.AttributeType.NUMBER),
@@ -174,16 +175,16 @@ class KnotsrepusArchiverStack(core.Stack):
             projection_type=dynamodb.ProjectionType.ALL
         )
 
-        metadata_table.auto_scale_global_secondary_index_read_capacity(
-            index_name="ArchiveMetadataByCreatedUtc",
-            min_capacity=5,
-            max_capacity=1000,
-        ).scale_on_utilization(target_utilization_percent=70)
-        metadata_table.auto_scale_global_secondary_index_write_capacity(
-            index_name="ArchiveMetadataByCreatedUtc",
-            min_capacity=5,
-            max_capacity=1000,
-        ).scale_on_utilization(target_utilization_percent=70)
+        # metadata_table.auto_scale_global_secondary_index_read_capacity(
+        #     index_name="ArchiveMetadataByDummyChronological",
+        #     min_capacity=5,
+        #     max_capacity=1000,
+        # ).scale_on_utilization(target_utilization_percent=70)
+        # metadata_table.auto_scale_global_secondary_index_write_capacity(
+        #     index_name="ArchiveMetadataByDummyChronological",
+        #     min_capacity=5,
+        #     max_capacity=1000,
+        # ).scale_on_utilization(target_utilization_percent=70)
         metadata_table.auto_scale_global_secondary_index_read_capacity(
             index_name="ArchiveMetadataByScore",
             min_capacity=5,

--- a/knotsrepus_archiver/knotsrepus_archiver_stack.py
+++ b/knotsrepus_archiver/knotsrepus_archiver_stack.py
@@ -145,11 +145,12 @@ class KnotsrepusArchiverStack(core.Stack):
         #     sort_key=dynamodb.Attribute(name="created_utc", type=dynamodb.AttributeType.NUMBER),
         #     projection_type=dynamodb.ProjectionType.ALL
         # )
-        metadata_table.add_global_secondary_index(
-            index_name="ArchiveMetadataByScore",
-            partition_key=dynamodb.Attribute(name="score", type=dynamodb.AttributeType.NUMBER),
-            projection_type=dynamodb.ProjectionType.ALL
-        )
+        # metadata_table.add_global_secondary_index(
+        #     index_name="ArchiveMetadataByDummyScore",
+        #     partition_key=dynamodb.Attribute(name="dummy", type=dynamodb.AttributeType.STRING),
+        #     sort_key=dynamodb.Attribute(name="score", type=dynamodb.AttributeType.NUMBER),
+        #     projection_type=dynamodb.ProjectionType.ALL
+        # )
         metadata_table.add_global_secondary_index(
             index_name="ArchiveMetadataByAuthorChronological",
             partition_key=dynamodb.Attribute(name="author", type=dynamodb.AttributeType.STRING),
@@ -185,16 +186,16 @@ class KnotsrepusArchiverStack(core.Stack):
         #     min_capacity=5,
         #     max_capacity=1000,
         # ).scale_on_utilization(target_utilization_percent=70)
-        metadata_table.auto_scale_global_secondary_index_read_capacity(
-            index_name="ArchiveMetadataByScore",
-            min_capacity=5,
-            max_capacity=1000,
-        ).scale_on_utilization(target_utilization_percent=70)
-        metadata_table.auto_scale_global_secondary_index_write_capacity(
-            index_name="ArchiveMetadataByScore",
-            min_capacity=5,
-            max_capacity=1000,
-        ).scale_on_utilization(target_utilization_percent=70)
+        # metadata_table.auto_scale_global_secondary_index_read_capacity(
+        #     index_name="ArchiveMetadataByDummyScore",
+        #     min_capacity=5,
+        #     max_capacity=1000,
+        # ).scale_on_utilization(target_utilization_percent=70)
+        # metadata_table.auto_scale_global_secondary_index_write_capacity(
+        #     index_name="ArchiveMetadataByDummyScore",
+        #     min_capacity=5,
+        #     max_capacity=1000,
+        # ).scale_on_utilization(target_utilization_percent=70)
         metadata_table.auto_scale_global_secondary_index_read_capacity(
             index_name="ArchiveMetadataByAuthorChronological",
             min_capacity=5,

--- a/knotsrepus_archiver/knotsrepus_archiver_stack.py
+++ b/knotsrepus_archiver/knotsrepus_archiver_stack.py
@@ -264,6 +264,8 @@ class KnotsrepusArchiverStack(core.Stack):
                     subject_alternative_names=["knotsrepus.net"],
                     validation=certificatemanager.CertificateValidation.from_dns(
                         hosted_zone=route53.PublicHostedZone.from_lookup(
+                            self,
+                            "HostedZone",
                             domain_name="knotsrepus.net",
                             private_zone=False
                         )

--- a/knotsrepus_archiver/knotsrepus_archiver_stack.py
+++ b/knotsrepus_archiver/knotsrepus_archiver_stack.py
@@ -260,6 +260,8 @@ class KnotsrepusArchiverStack(core.Stack):
             domain_name=apigateway.DomainName(
                 domain_name="api.knotsrepus.net",
                 certificate=certificatemanager.Certificate(
+                    self,
+                    "Certificate",
                     domain_name="*.knotsrepus.net",
                     subject_alternative_names=["knotsrepus.net"],
                     validation=certificatemanager.CertificateValidation.from_dns(

--- a/src/common/metadata.py
+++ b/src/common/metadata.py
@@ -29,10 +29,10 @@ class DynamoDBMetadataService(MetadataService):
     index_for_key_and_sort = {
         ("author", "created_utc"): "ArchiveMetadataByAuthorChronological",
         ("author", "score"): "ArchiveMetadataByAuthorScore",
-        ("created_utc", None): "ArchiveMetadataByCreatedUtc",
+        ("dummy", "created_utc"): "ArchiveMetadataByDummyChronological",
         ("post_type", "created_utc"): "ArchiveMetadataByPostTypeChronological",
         ("post_type", "score"): "ArchiveMetadataByPostTypeScore",
-        ("score", None): "ArchiveMetadataByScore",
+        ("dummy", "score"): "ArchiveMetadataByDummyScore",
     }
 
     def __init__(self, session: aioboto3.Session, table_name: str):

--- a/src/common/metadata.py
+++ b/src/common/metadata.py
@@ -1,7 +1,8 @@
 from abc import ABC, abstractmethod
+from typing import Union
 
 import aioboto3
-from boto3.dynamodb.conditions import ConditionBase
+from boto3.dynamodb.conditions import ConditionBase, AttributeBase
 
 from src.common import log_utils
 
@@ -123,10 +124,14 @@ class DynamoDBMetadataService(MetadataService):
             return response["Items"]
 
     @staticmethod
-    def get_key_name(key_condition: ConditionBase):
+    def get_key_name(key_condition: Union[ConditionBase, AttributeBase]):
         expr_values = key_condition.get_expression()["values"]
-        sub_expr_values = expr_values[0].get_expression()["values"]
-        return sub_expr_values[0].name
+        sub_expr = expr_values[0]
+
+        if isinstance(sub_expr, AttributeBase):
+            return sub_expr.name
+
+        return DynamoDBMetadataService.get_key_name(sub_expr)
 
 
 class StubMetadataService(MetadataService):

--- a/src/common/metadata.py
+++ b/src/common/metadata.py
@@ -149,6 +149,9 @@ class StubMetadataService(MetadataService):
             "title": submission_id,
             "score": 1,
             "post_type": "DD",
+            "subreddit": "Superstonk",
+            "last_updated": 1630460000,
+            "dummy": "",
         }
 
     async def put(self, submission_id: str, metadata):

--- a/src/common/syncio.py
+++ b/src/common/syncio.py
@@ -1,0 +1,28 @@
+import asyncio
+
+
+def iterate_synchronously(ait, loop=None):
+    if loop is None:
+        loop = asyncio.get_event_loop()
+
+    ait = ait.__aiter__()
+
+    async def get_next():
+        try:
+            obj = await ait.__anext__()
+            return False, obj
+        except StopAsyncIteration:
+            return True, None
+
+    while True:
+        done, obj = loop.run_until_complete(get_next())
+        if done:
+            break
+        yield obj
+
+
+def run_synchronously(future, loop=None):
+    if loop is None:
+        loop = asyncio.get_event_loop()
+
+    return loop.run_until_complete(future)

--- a/src/knotsrepus-api-lambda/api_controller.py
+++ b/src/knotsrepus-api-lambda/api_controller.py
@@ -1,0 +1,79 @@
+import base64
+import json
+import mimetypes
+
+from boto3.dynamodb.conditions import Key, Attr
+
+import rest
+from src.common.filesystem import FileSystem
+from src.common.metadata import MetadataService
+from src.common.syncio import run_synchronously, iterate_synchronously
+
+
+class ApiController:
+    def __init__(self, filesystem: FileSystem, metadata_service: MetadataService):
+        self.filesystem = filesystem
+        self.metadata_service = metadata_service
+
+    @rest.route(path="/submission")
+    def get_submissions(self, author=None, post_type=None, sort=None, sort_order="asc", after_id=None, count=100, **kwargs):
+        count = min(count, 100)
+
+        if author is None and post_type is None:
+            coroutine = self.metadata_service.list(after_id, count, sort, sort_order)
+        elif author is not None:
+            key_condition = Key("author").eq(author)
+            if post_type is None:
+                coroutine = self.metadata_service.query(key_condition, after_id, count, sort, sort_order)
+            else:
+                coroutine = self.metadata_service.query(
+                    key_condition,
+                    Attr("post_type").eq(post_type),
+                    after_id,
+                    count,
+                    sort,
+                    sort_order
+                )
+        else:
+            coroutine = self.metadata_service.query(Key("post_type").eq(post_type), after_id, count, sort, sort_order)
+
+        data = run_synchronously(coroutine)
+
+        if data is not None:
+            return "application/json", data
+
+        return None
+
+    @rest.route(path="/submission/{submission_id}")
+    def get_submission(self, submission_id, **kwargs):
+        data = run_synchronously(self.filesystem.read(f"{submission_id}/post.json"))
+
+        if data is not None:
+            return "application/json", json.loads(data)
+
+        return None
+
+    @rest.route(path="/submission/{submission_id}/comments")
+    def get_comments(self, submission_id, **kwargs):
+        data = run_synchronously(self.filesystem.read(f"{submission_id}/comments.json"))
+
+        if data is not None:
+            return "application/json", json.loads(data)
+
+        return None
+
+    @rest.route(path="/submission/{submission_id}/media")
+    def get_media_list(self, submission_id, **kwargs):
+        media = iterate_synchronously(self.filesystem.list_files(submission_id))
+
+        return "application/json", list(media)
+
+    @rest.route(path="/submission/{submission_id}/media/{filename}")
+    def get_media_object(self, submission_id, filename, **kwargs):
+        data = run_synchronously(self.filesystem.read(f"{submission_id}/{filename}"))
+
+        if data is not None:
+            content_type, _ = mimetypes.guess_type(filename)
+            return content_type, base64.b64encode(data).decode("utf-8")
+
+        return None

--- a/src/knotsrepus-api-lambda/api_controller.py
+++ b/src/knotsrepus-api-lambda/api_controller.py
@@ -22,7 +22,7 @@ class ApiController:
         sort_key = Key(sort).gte(0)
         if author is None and post_type is None:
             coroutine = self.metadata_service.query(
-                Key("dummy").eq("") & sort_key,
+                Key("dummy").eq("dummy") & sort_key,
                 after_id=after_id,
                 limit=count,
                 sort=sort,

--- a/src/knotsrepus-api-lambda/api_controller.py
+++ b/src/knotsrepus-api-lambda/api_controller.py
@@ -22,9 +22,10 @@ class ApiController:
         sort_key = Key(sort).gte(0)
         if author is None and post_type is None:
             coroutine = self.metadata_service.query(
-                sort_key,
+                Key("dummy").eq("") & sort_key,
                 after_id=after_id,
                 limit=count,
+                sort=sort,
                 sort_order=sort_order
             )
         elif author is not None:

--- a/src/knotsrepus-api-lambda/event.json
+++ b/src/knotsrepus-api-lambda/event.json
@@ -1,0 +1,12 @@
+{
+  "resource": "/submission/",
+  "pathParameters": {
+    "submission_id": "ml197j",
+    "filename": "714v1izjogr61.png"
+  },
+  "queryStringParameters": {
+    "post_type": "dd",
+    "sort": "score",
+    "sort_order": "desc"
+  }
+}

--- a/src/knotsrepus-api-lambda/event.json
+++ b/src/knotsrepus-api-lambda/event.json
@@ -1,9 +1,5 @@
 {
-  "resource": "/submission/",
-  "pathParameters": {
-    "submission_id": "ml197j",
-    "filename": "714v1izjogr61.png"
-  },
+  "path": "/submission/ml197j/media/714v1izjogr61.png",
   "queryStringParameters": {
     "post_type": "dd",
     "sort": "score",

--- a/src/knotsrepus-api-lambda/event.json
+++ b/src/knotsrepus-api-lambda/event.json
@@ -1,8 +1,123 @@
 {
-  "path": "/submission/ml197j/media/714v1izjogr61.png",
+  "body": "eyJ0ZXN0IjoiYm9keSJ9",
+  "resource": "/{proxy+}",
+  "path": "/submission",
+  "httpMethod": "GET",
+  "isBase64Encoded": true,
   "queryStringParameters": {
-    "post_type": "dd",
-    "sort": "score",
-    "sort_order": "desc"
+    "author": "Criand"
+  },
+  "multiValueQueryStringParameters": {
+    "foo": [
+      "bar"
+    ]
+  },
+  "pathParameters": {
+    "proxy": "/path/to/resource"
+  },
+  "stageVariables": {
+    "baz": "qux"
+  },
+  "headers": {
+    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
+    "Accept-Encoding": "gzip, deflate, sdch",
+    "Accept-Language": "en-US,en;q=0.8",
+    "Cache-Control": "max-age=0",
+    "CloudFront-Forwarded-Proto": "https",
+    "CloudFront-Is-Desktop-Viewer": "true",
+    "CloudFront-Is-Mobile-Viewer": "false",
+    "CloudFront-Is-SmartTV-Viewer": "false",
+    "CloudFront-Is-Tablet-Viewer": "false",
+    "CloudFront-Viewer-Country": "US",
+    "Host": "1234567890.execute-api.us-east-1.amazonaws.com",
+    "Upgrade-Insecure-Requests": "1",
+    "User-Agent": "Custom User Agent String",
+    "Via": "1.1 08f323deadbeefa7af34d5feb414ce27.cloudfront.net (CloudFront)",
+    "X-Amz-Cf-Id": "cDehVQoZnx43VYQb9j2-nvCh-9z396Uhbp027Y2JvkCPNLmGJHqlaA==",
+    "X-Forwarded-For": "127.0.0.1, 127.0.0.2",
+    "X-Forwarded-Port": "443",
+    "X-Forwarded-Proto": "https"
+  },
+  "multiValueHeaders": {
+    "Accept": [
+      "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8"
+    ],
+    "Accept-Encoding": [
+      "gzip, deflate, sdch"
+    ],
+    "Accept-Language": [
+      "en-US,en;q=0.8"
+    ],
+    "Cache-Control": [
+      "max-age=0"
+    ],
+    "CloudFront-Forwarded-Proto": [
+      "https"
+    ],
+    "CloudFront-Is-Desktop-Viewer": [
+      "true"
+    ],
+    "CloudFront-Is-Mobile-Viewer": [
+      "false"
+    ],
+    "CloudFront-Is-SmartTV-Viewer": [
+      "false"
+    ],
+    "CloudFront-Is-Tablet-Viewer": [
+      "false"
+    ],
+    "CloudFront-Viewer-Country": [
+      "US"
+    ],
+    "Host": [
+      "0123456789.execute-api.us-east-1.amazonaws.com"
+    ],
+    "Upgrade-Insecure-Requests": [
+      "1"
+    ],
+    "User-Agent": [
+      "Custom User Agent String"
+    ],
+    "Via": [
+      "1.1 08f323deadbeefa7af34d5feb414ce27.cloudfront.net (CloudFront)"
+    ],
+    "X-Amz-Cf-Id": [
+      "cDehVQoZnx43VYQb9j2-nvCh-9z396Uhbp027Y2JvkCPNLmGJHqlaA=="
+    ],
+    "X-Forwarded-For": [
+      "127.0.0.1, 127.0.0.2"
+    ],
+    "X-Forwarded-Port": [
+      "443"
+    ],
+    "X-Forwarded-Proto": [
+      "https"
+    ]
+  },
+  "requestContext": {
+    "accountId": "123456789012",
+    "resourceId": "123456",
+    "stage": "prod",
+    "requestId": "c6af9ac6-7b61-11e6-9a41-93e8deadbeef",
+    "requestTime": "09/Apr/2015:12:34:56 +0000",
+    "requestTimeEpoch": 1428582896000,
+    "identity": {
+      "cognitoIdentityPoolId": null,
+      "accountId": null,
+      "cognitoIdentityId": null,
+      "caller": null,
+      "accessKey": null,
+      "sourceIp": "127.0.0.1",
+      "cognitoAuthenticationType": null,
+      "cognitoAuthenticationProvider": null,
+      "userArn": null,
+      "userAgent": "Custom User Agent String",
+      "user": null
+    },
+    "path": "/prod/path/to/resource",
+    "resourcePath": "/{proxy+}",
+    "httpMethod": "POST",
+    "apiId": "1234567890",
+    "protocol": "HTTP/1.1"
   }
 }

--- a/src/knotsrepus-api-lambda/main.py
+++ b/src/knotsrepus-api-lambda/main.py
@@ -39,23 +39,20 @@ def format_response(status_code, content_type, body):
 
 
 def dispatch_event_to_api_controller(event, context):
-    resource = event.get("resource")
+    path = event.get("path")
 
-    if resource.endswith("/"):
-        resource = resource[:-1]
+    if path.endswith("/"):
+        path = path[:-1]
 
-    if not rest.route_is_defined(resource):
+    if not rest.route_is_defined(path):
         return format_response(400,
                                "application/json",
-                               {"message": f"No controller function defined to handle resource '{resource}'"})
+                               {"message": f"No controller function defined to handle path '{path}'"})
 
     api = get_api_controller(context)
-    path_params = event.get("pathParameters") or dict()
     query_params = event.get("queryStringParameters") or dict()
 
-    params = {**path_params, **query_params}
-
-    (content_type, body) = rest.dispatch(resource, api, **params)
+    (content_type, body) = rest.dispatch(path, api, **query_params)
 
     return format_response(200, content_type, body)
 

--- a/src/knotsrepus-api-lambda/main.py
+++ b/src/knotsrepus-api-lambda/main.py
@@ -1,4 +1,4 @@
-import json
+import simplejson as json
 import os
 
 import aioboto3

--- a/src/knotsrepus-api-lambda/main.py
+++ b/src/knotsrepus-api-lambda/main.py
@@ -1,0 +1,71 @@
+import json
+import os
+
+import aioboto3
+
+from src.common.filesystem import StubFileSystem, S3FileSystem
+from src.common.lambda_context import local_lambda_invocation
+
+import api_controller
+import rest
+from src.common.metadata import StubMetadataService, DynamoDBMetadataService
+
+
+def get_api_controller(context):
+    if context is local_lambda_invocation:
+        filesystem = StubFileSystem()
+        metadata_service = StubMetadataService()
+    else:
+        session = aioboto3.Session()
+
+        bucket_name = os.environ.get("ARCHIVE_DATA_BUCKET")
+        metadata_table_name = os.environ.get("METADATA_TABLE_NAME")
+
+        filesystem = S3FileSystem(bucket_name)
+        metadata_service = DynamoDBMetadataService(session, metadata_table_name)
+
+    return api_controller.ApiController(filesystem, metadata_service)
+
+
+def format_response(status_code, content_type, body):
+    is_binary = any(prefix in content_type for prefix in ["image", "video", "audio"])
+
+    return {
+        "statusCode": status_code,
+        "headers": {"Content-Type": content_type},
+        "isBase64Encoded": is_binary,
+        "body": body if is_binary else json.dumps(body)
+    }
+
+
+def dispatch_event_to_api_controller(event, context):
+    resource = event.get("resource")
+
+    if resource.endswith("/"):
+        resource = resource[:-1]
+
+    if not rest.route_is_defined(resource):
+        return format_response(400,
+                               "application/json",
+                               {"message": f"No controller function defined to handle resource '{resource}'"})
+
+    api = get_api_controller(context)
+    path_params = event.get("pathParameters") or dict()
+    query_params = event.get("queryStringParameters") or dict()
+
+    params = {**path_params, **query_params}
+
+    (content_type, body) = rest.dispatch(resource, api, **params)
+
+    return format_response(200, content_type, body)
+
+
+def handler(event, context):
+    return dispatch_event_to_api_controller(event, context)
+
+
+if __name__ == "__main__":
+    with open("event.json", "r") as file:
+        event = json.load(file)
+
+    print(handler(event, local_lambda_invocation))

--- a/src/knotsrepus-api-lambda/rest.py
+++ b/src/knotsrepus-api-lambda/rest.py
@@ -1,3 +1,5 @@
+import re
+
 __ROUTES = dict()
 
 
@@ -9,9 +11,29 @@ def route(path):
 
 
 def route_is_defined(path):
-    return path in __ROUTES
+    fn, _ = match_route(path)
+    return fn is not None
 
 
 def dispatch(path, *args, **kwargs):
-    fn = __ROUTES.get(path)
+    fn, path_params = match_route(path)
+    kwargs.update(path_params)
     return fn(*args, **kwargs)
+
+
+def match_route(path):
+    if path in __ROUTES:
+        return __ROUTES[path], {}
+
+    def make_pattern(route):
+        return "^" + re.sub(r"{(\w+)}", r"(?P<\1>[^/]+)", route) + "$"
+
+    for key, value in __ROUTES.items():
+        match = re.match(make_pattern(key), path)
+
+        if match is None:
+            continue
+
+        return value, match.groupdict()
+
+    return None, None

--- a/src/knotsrepus-api-lambda/rest.py
+++ b/src/knotsrepus-api-lambda/rest.py
@@ -1,0 +1,17 @@
+__ROUTES = dict()
+
+
+def route(path):
+    def decorator(fn):
+        __ROUTES[path] = fn
+        return fn
+    return decorator
+
+
+def route_is_defined(path):
+    return path in __ROUTES
+
+
+def dispatch(path, *args, **kwargs):
+    fn = __ROUTES.get(path)
+    return fn(*args, **kwargs)

--- a/src/knotsrepus-api-lambda/rest.py
+++ b/src/knotsrepus-api-lambda/rest.py
@@ -18,7 +18,37 @@ def route_is_defined(path):
 def dispatch(path, *args, **kwargs):
     fn, path_params = match_route(path)
     kwargs.update(path_params)
+    kwargs = coerce_param_types(kwargs)
     return fn(*args, **kwargs)
+
+
+def coerce_param_types(params: dict):
+    for key, value in params.items():
+        try:
+            value = int(value)
+            params[key] = value
+            continue
+        except ValueError:
+            # Okay as an attempt will be made to parse as a float or bool before continuing as a string.
+            pass
+
+        try:
+            value = float(value)
+            params[key] = value
+            continue
+        except ValueError:
+            # Okay as an attempt will be made to parse as a bool before continuing as a string.
+            pass
+
+        if value.lower() == "true":
+            params[key] = True
+        elif value.lower() == "false":
+            params[key] = False
+        else:
+            # Keep value as a string.
+            pass
+
+    return params
 
 
 def match_route(path):

--- a/src/metadata-generator/main.py
+++ b/src/metadata-generator/main.py
@@ -79,7 +79,7 @@ async def main(config_source: ArchiverConfigSource, filesystem: FileSystem, meta
             # All metadata items need to have a column with a constant value that can be used as a partition key in a
             # secondary index, to enable queries that order by score or creation time in reverse order without resorting
             # to an expensive table scan.
-            "dummy": "",
+            "dummy": "dummy",
         }
 
         await metadata_service.put(submission_id, metadata)

--- a/src/metadata-generator/main.py
+++ b/src/metadata-generator/main.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 import os
+from datetime import datetime
 
 import aioboto3
 
@@ -41,7 +42,13 @@ async def main(config_source: ArchiverConfigSource, filesystem: FileSystem, meta
     logger = log_utils.get_logger("metadata-generator")
     logger.info("Building KNOTSREPUS archive metadata...")
 
-    last_generated_metadata = await config_source.get_config("last_generated_metadata") or ""
+    command = await config_source.get_config("metadata_control_command")
+    if command == "rebuild":
+        last_generated_metadata = ""
+        await config_source.put_config(metadata_control_command="resume")
+    else:
+        last_generated_metadata = await config_source.get_config("last_generated_metadata") or ""
+
     metadata_count = 0
 
     async for dir in filesystem.list_dirs(StartAfter=last_generated_metadata):
@@ -61,6 +68,13 @@ async def main(config_source: ArchiverConfigSource, filesystem: FileSystem, meta
             "title": data["title"],
             "score": data["score"],
             "post_type": post_type,
+            "subreddit": data["subreddit"],
+            "last_updated": int(datetime.utcnow().timestamp()),
+
+            # All metadata items need to have a column with a constant value that can be used as a partition key in a
+            # secondary index, to enable queries that order by score or creation time in reverse order without resorting
+            # to an expensive table scan.
+            "dummy": "",
         }
 
         await metadata_service.put(submission_id, metadata)

--- a/src/metadata-generator/main.py
+++ b/src/metadata-generator/main.py
@@ -44,10 +44,15 @@ async def main(config_source: ArchiverConfigSource, filesystem: FileSystem, meta
 
     command = await config_source.get_config("metadata_control_command")
     if command == "rebuild":
+        logger.info("Metadata store rebuild was requested.")
         last_generated_metadata = ""
         await config_source.put_config(metadata_control_command="resume")
     else:
         last_generated_metadata = await config_source.get_config("last_generated_metadata") or ""
+        if last_generated_metadata == "":
+            logger.info("Metadata generation starting from the beginning.")
+        else:
+            logger.info(f"Metadata generation resuming from after submission '{last_generated_metadata}'.")
 
     metadata_count = 0
 

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -4,3 +4,4 @@ aioboto3==9.0.0
 python-dateutil==2.8.1
 boto3==1.17.49
 botocore==1.20.49
+simplejson==3.17.5


### PR DESCRIPTION
The API currently lives in https://github.com/knotsrepus/knotsrepus-api. However, to take advantage of new parts of the KNOTSREPUS system, such as the metadata table, and reuse common code, it makes sense to bring it into this repository so it can be maintained and deployed with the CloudFormation stack.

Changes:
* Ported code from knotsrepus-api repository, refactoring to take advantage of common code and new metadata features
* Added query string parameters to the `/submissions` endpoint to allow filtering and sorting
* `/submissions` endpoint now uses pagination with `after_id` and `count` parameters (limited to 100 per page)